### PR TITLE
BAQE-1915 - Go over TODOs and ask Karm about some parts of the code

### DIFF
--- a/kogito-benchmarks-framework/src/main/java/org/kie/kogito/benchmarks/framework/Commands.java
+++ b/kogito-benchmarks-framework/src/main/java/org/kie/kogito/benchmarks/framework/Commands.java
@@ -438,8 +438,7 @@ public class Commands {
      * 3.473028811 seconds time elapsed
      */
 
-    // TODO Ask Karm about this
-    public static void processStopper(Process p, boolean force) throws InterruptedException, IOException {
+    public static void processStopper(Process p, boolean force) throws InterruptedException {
         p.children().forEach(child -> {
             if (child.supportsNormalTermination()) {
                 child.destroy();

--- a/kogito-benchmarks-tests/src/test/java/org/kie/kogito/benchmarks/AbstractTemplateTest.java
+++ b/kogito-benchmarks-tests/src/test/java/org/kie/kogito/benchmarks/AbstractTemplateTest.java
@@ -116,7 +116,6 @@ public abstract class AbstractTemplateTest {
                 runLogA = runInfo.getRunLog();
 
                 logger.info("Terminate and scan logs...");
-                pA.getInputStream().available(); // TODO Ask Karm
 
                 long rssKb = getRSSkB(pA.pid());
                 long openedFiles = getOpenedFDs(pA.pid());


### PR DESCRIPTION
* It is enough for the `processStopper` to stop just children of the process and not to go deeper. Quarkus/Spring Boot don't create grandchild processes.
* `pA.getInputStream()` returns `NullInputStream` in case the output of the process is redirected to a file. So `pA.getInputStream().available()` always returns 0.